### PR TITLE
AVO-4090 retry failed jobs, improved error handling

### DIFF
--- a/app/redactietool.py
+++ b/app/redactietool.py
@@ -622,6 +622,22 @@ def transcription_status(department, pid):
             error_text = ' '.join(errors) if errors else None
             jobs_service.update_job(job["id"], status=status, errors=error_text)
 
+            if status == 'done':
+                logger.info('transcription_status: job done, fetching result immediately', data={'job_id': job["id"]})
+                try:
+                    result = speechmatics_api.get_job_result(job["speechmatic_job_id"])
+                    processed_result = speechmatics_api.parse_result(result)
+                    jobs_service.mark_processed(
+                        job_id=job["id"],
+                        transcription=processed_result.get('transcription'),
+                        summary=processed_result.get('summary'),
+                        chapters=json.dumps(processed_result.get('chapters')),
+                        status='done',
+                    )
+                    logger.info('transcription_status: result stored', data={'job_id': job["id"]})
+                except Exception as result_ex:
+                    logger.exception('transcription_status: failed to fetch/store result', data={'job_id': job["id"], 'error': str(result_ex)})
+
         return {
             'job_id': job["id"],
             'status': status,

--- a/app/redactietool.py
+++ b/app/redactietool.py
@@ -425,6 +425,7 @@ def save_item_metadata():
         logger.error('save_item_metadata: failed to fetch job data', data={'pid': pid, 'error': str(ex)})
         speechmatics_data = None
     template_vars['sm_job_status'] = speechmatics_data.get('status') if speechmatics_data else None
+    template_vars['sm_job_errors'] = speechmatics_data.get('errors') if speechmatics_data else None
     template_vars['sm_job_transcription'] = speechmatics_data.get('transcription') if speechmatics_data else None
     template_vars['sm_job_summary'] = speechmatics_data.get('summary') if speechmatics_data else None
     template_vars['sm_job_chapters'] = json.loads(speechmatics_data['chapters']) if speechmatics_data and isinstance(speechmatics_data.get('chapters'), str) else (speechmatics_data.get('chapters') if speechmatics_data else None)
@@ -564,7 +565,7 @@ def generate_transcript():
             }, HTTPStatus.NOT_FOUND
         
         job = jobs_service.get_job(department, pid)
-        if job and job["processed_at"] is None:
+        if job and job["status"] in ('created', 'running'):
             return {
                 'error': f'Job already exists for pid: {pid} with status: {job["status"]}, but not processed yet'
             }, HTTPStatus.CONFLICT
@@ -589,7 +590,7 @@ def generate_transcript():
             jobs_service.create_job(department, pid, job_id)
         else:
             logger.info(f"Job already exists for pid: {pid}, updating with new job_id: {job_id} and resetting status")
-            jobs_service.update_job(job["id"], speechmatic_job_id=job_id)
+            jobs_service.update_job(job["id"], speechmatic_job_id=job_id, status='created', processed_at=None)
         return {
             'department': department,
             'pid': pid,
@@ -614,14 +615,17 @@ def transcription_status(department, pid):
                 'status': 'not found'
             }, HTTPStatus.NOT_FOUND
         if (job["processed_at"] is not None):
-            status = job["status"] 
+            status = job["status"]
+            errors = []
         else:
-            status = speechmatics_api.get_job_status(job["speechmatic_job_id"])
-            jobs_service.update_job_status(job["id"], status)
+            status, errors = speechmatics_api.get_job_status(job["speechmatic_job_id"])
+            error_text = ' '.join(errors) if errors else None
+            jobs_service.update_job(job["id"], status=status, errors=error_text)
 
         return {
             'job_id': job["id"],
-            'status': status
+            'status': status,
+            'errors': errors,
         }, HTTPStatus.OK
     except Exception as ex:
         logger.exception(

--- a/app/services/jobs.py
+++ b/app/services/jobs.py
@@ -110,7 +110,7 @@ class JobsService:
         department, pid, processed_at, speechmatic_job_id, transcription, summary.
         """
         allowed = {'department', 'pid', 'processed_at', 'speechmatic_job_id',
-                   'transcription', 'summary', 'chapters', 'status'}
+                   'transcription', 'summary', 'chapters', 'status', 'errors'}
         updates = {k: v for k, v in fields.items() if k in allowed}
         if not updates:
             return self.get_job_by_id(job_id)

--- a/app/services/jobs_cron.py
+++ b/app/services/jobs_cron.py
@@ -39,10 +39,11 @@ def fetch_pending_results():
         job_id = job['id']
         speechmatic_job_id = job['speechmatic_job_id']
         try:
-            remote_status = speechmatics_api.get_job_status(speechmatic_job_id)
+            remote_status, remote_errors = speechmatics_api.get_job_status(speechmatic_job_id)
             if remote_status != job['status']:
-                jobs_service.update_job_status(job_id, remote_status)
-                logger.info('cron: updated job status', data={'job_id': job_id, 'status': remote_status})
+                error_text = ' '.join(remote_errors) if remote_errors else None
+                jobs_service.update_job(job_id, status=remote_status, errors=error_text)
+                logger.info('cron: updated job status', data={'job_id': job_id, 'status': remote_status, 'errors': remote_errors})
         except Exception as ex:
             logger.error('cron: failed to fetch status', data={'job_id': job_id, 'error': str(ex)})
 

--- a/app/services/meta_mapping.py
+++ b/app/services/meta_mapping.py
@@ -160,6 +160,7 @@ class MetaMapping:
             'validation_errors': errors,
             # speechmatics data
             'sm_job_status': sm_data.get('status') if sm_data else None,
+            'sm_job_errors': sm_data.get('errors') if sm_data else None,
             'sm_job_transcription': sm_data.get('transcription') if sm_data else None,
             'sm_job_summary': sm_data.get('summary') if sm_data else None,
             'sm_job_chapters': json.loads(sm_data['chapters']) if sm_data and isinstance(sm_data.get('chapters'), str) else (sm_data.get('chapters') if sm_data else None),

--- a/app/services/speechmatic_api.py
+++ b/app/services/speechmatic_api.py
@@ -60,15 +60,17 @@ class SpeechmaticsApi:
 				headers=self._headers(),
 				files={"config": (None, json.dumps(config), "application/json")},
 			)
+			logger.info(f"Speechmatics launch_job response: status={response.status_code} body={response.text}")
+			response.raise_for_status()
 			job_id = response.json()["id"]
-			logger.info(f"Received response from Speechmatics, job {job_id}")
+			logger.info(f"Speechmatics job created: {job_id}")
 			return job_id
 		except requests.HTTPError as e:
-			logger.exception(f"Error launching transcription job for audio {audio_path}: {e.response.text}")
+			logger.exception(f"Error launching transcription job for audio {audio_path}: status={e.response.status_code} body={e.response.text}")
 			raise
 
-	def get_job_status(self, job_id: str) -> str:
-		"""Return the current status string of the transcription job *job_id*."""
+	def get_job_status(self, job_id: str) -> tuple[str, list]:
+		"""Return (status, errors) for the transcription job *job_id*."""
 		if(job_id is None):
 			logger.error("Job ID is required to fetch job result")
 			raise ValueError("Job ID is required to fetch job result")
@@ -77,11 +79,14 @@ class SpeechmaticsApi:
 				f"{self.base_url}/v2/jobs/{job_id}",
 				headers=self._headers(),
 			)
-			logger.info(f"Fetched job status from Speechmatics for job {job_id}")
+			logger.info(f"Speechmatics get_job_status response: job={job_id} status={response.status_code} body={response.text}")
+			response.raise_for_status()
 			responseData = response.json()
-			return responseData["job"]["status"]
+			job = responseData["job"]
+			errors = [e.get("message", "") for e in job.get("errors", [])]
+			return job["status"], errors
 		except requests.HTTPError as e:
-			logger.exception(f"Error fetching job status for job {job_id}: {e.response.text}")
+			logger.exception(f"Error fetching job status for job {job_id}: status={e.response.status_code} body={e.response.text}")
 			raise
 
 	def get_job_result(self, job_id: str) -> dict:
@@ -94,12 +99,14 @@ class SpeechmaticsApi:
 				f"{self.base_url}/v2/jobs/{job_id}/transcript",
 				headers=self._headers(),
 			)
+			logger.info(f"Speechmatics get_job_result response: job={job_id} status={response.status_code}")
 			response.raise_for_status()
-			logger.info(f"Successfully fetched job result from Speechmatics for job {job_id}")
-			return response.json()
+			response_json = response.json()
+			logger.info(f"Successfully fetched job result from Speechmatics for job {job_id}: {json.dumps(response_json)}")
+			return response_json
 		except requests.HTTPError as e:
 			error_body = e.response.text if e.response is not None else str(e)
-			logger.exception(f"Error fetching job result for job {job_id}: {error_body}")
+			logger.exception(f"Error fetching job result for job {job_id}: status={e.response.status_code if e.response is not None else 'N/A'} body={error_body}")
 			raise
 
 	def list_jobs(self) -> list:

--- a/app/templates/metadata/components/ai_generate_controls.html
+++ b/app/templates/metadata/components/ai_generate_controls.html
@@ -25,15 +25,6 @@
   </div>
 </div>
 
-{% if sm_job_status in ['rejected', 'deleted'] %}
-<div class="notification is-danger is-light mt-2" id="ai_status_error">
-  De vorige aanvraag voor AI inhoud is mislukt. Je kan een nieuwe aanvraag indienen.
-</div>
-{% else %}
-<div class="notification is-danger is-light mt-2" id="ai_status_error" style="display:none;"></div>
-{% endif %}
-
-
 <script>
   (function () {
     var btn = document.getElementById('request_ai_content_btn');
@@ -72,16 +63,27 @@
       btn.disabled = false;
     }
 
-    function showError(message) {
+    function showError(message, details) {
       var el = document.getElementById('ai_status_error');
       if (!el) return;
       el.textContent = message;
+      if (details && details.length > 0) {
+        var small = document.createElement('small');
+        small.style.display = 'block';
+        small.style.marginTop = '0.25rem';
+        small.textContent = details.join(' ');
+        el.appendChild(small);
+      }
       el.style.display = '';
+      var sectionEl = document.getElementById('ai_section_status_error');
+      if (sectionEl) sectionEl.style.display = '';
     }
 
     function hideError() {
       var el = document.getElementById('ai_status_error');
       if (el) el.style.display = 'none';
+      var sectionEl = document.getElementById('ai_section_status_error');
+      if (sectionEl) sectionEl.style.display = 'none';
     }
 
     var pollingInterval = null;
@@ -105,9 +107,9 @@
               pollingInterval = null;
               setButtonReady();
               if (status === 'rejected' || status === 'deleted') {
-                showError('De aanvraag voor AI inhoud is mislukt. Je kan een nieuwe aanvraag indienen.');
+                showError('De aanvraag voor AI inhoud is mislukt. Je kan een nieuwe aanvraag indienen.', data.errors);
               } else if (status === 'expired') {
-                showError('De aanvraag voor AI inhoud is verlopen. Je kan een nieuwe aanvraag indienen.');
+                showError('De aanvraag voor AI inhoud is verlopen. Je kan een nieuwe aanvraag indienen.', data.errors);
               }
             }
           })

--- a/app/templates/metadata/edit.html
+++ b/app/templates/metadata/edit.html
@@ -87,7 +87,16 @@ Metadata bewerken
             
           {% include 'metadata/components/ai_generate_controls.html' %}
         </div>
-        
+
+        {% if sm_job_status in ['rejected', 'deleted'] %}
+        <div class="notification is-danger is-light mt-2" id="ai_status_error">
+          De vorige aanvraag voor AI inhoud is mislukt. Je kan een nieuwe aanvraag indienen.
+          {% if sm_job_errors %}<br><small>{{ sm_job_errors }}</small>{% endif %}
+        </div>
+        {% else %}
+        <div class="notification is-danger is-light mt-2" id="ai_status_error" style="display:none;"></div>
+        {% endif %}
+
         <div id="ai_toast_container" class="mt-3"></div>
 
       </div>

--- a/app/templates/metadata/sections/ai_generated_section.html
+++ b/app/templates/metadata/sections/ai_generated_section.html
@@ -55,14 +55,15 @@
               De AI gegenereerde inhoud is aangevraagd en wordt momenteel verwerkt. Kom later terug om de resultaten te bekijken.
             </div>
         {% elif sm_job_status in ['rejected', 'deleted', 'expired'] %}
-          <div class="notification is-danger">
-            De aanvraag voor AI gegenereerde inhoud is mislukt of verlopen. Er kan een nieuwe aanvraag worden ingediend door de originele taal van het audio/beeldfragment te selecteren en op de knop te klikken bovenaan de pagina.
-          </div>    
         {% elif sm_job_status is none %}
           <div class="notification is-light">
             Er is nog geen AI gegenereerde inhoud beschikbaar voor dit item. Selecteer de originele taal van het audio/beeldfragment en op de knop te klikken bovenaan de pagina.
           </div>
         {% endif %}
+        <div class="notification is-danger" id="ai_section_status_error"{% if sm_job_status not in ['rejected', 'deleted', 'expired'] %} style="display:none;"{% endif %}>
+          De aanvraag voor AI gegenereerde inhoud is mislukt of verlopen. Er kan een nieuwe aanvraag worden ingediend door de originele taal van het audio/beeldfragment te selecteren en op de knop te klikken bovenaan de pagina.
+          {% if sm_job_errors %}<br><small>{{ sm_job_errors }}</small>{% endif %}
+        </div>
 
 
 

--- a/db/init/02_add_errors_column.sql
+++ b/db/init/02_add_errors_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.jobs ADD COLUMN IF NOT EXISTS errors text;

--- a/tests/test_speechmatic_api.py
+++ b/tests/test_speechmatic_api.py
@@ -93,8 +93,9 @@ class TestGetJobStatus:
         api = _make_api(monkeypatch)
         resp = _mock_response({'job': {'status': 'running'}})
         with patch('app.services.speechmatic_api.requests.get', return_value=resp):
-            status = api.get_job_status('job-xyz')
+            status, errors = api.get_job_status('job-xyz')
         assert status == 'running'
+        assert errors == []
 
     def test_calls_correct_url(self, monkeypatch):
         api = _make_api(monkeypatch, base_url='https://eu1.asr.api.speechmatics.com')
@@ -107,7 +108,18 @@ class TestGetJobStatus:
         api = _make_api(monkeypatch)
         resp = _mock_response({'job': {'status': 'done'}})
         with patch('app.services.speechmatic_api.requests.get', return_value=resp):
-            assert api.get_job_status('j') == 'done'
+            status, errors = api.get_job_status('j')
+        assert status == 'done'
+        assert errors == []
+
+    def test_returns_errors_on_rejected(self, monkeypatch):
+        api = _make_api(monkeypatch)
+        body = {'job': {'status': 'rejected', 'errors': [{'message': 'limit exceeded'}]}}
+        resp = _mock_response(body)
+        with patch('app.services.speechmatic_api.requests.get', return_value=resp):
+            status, errors = api.get_job_status('j')
+        assert status == 'rejected'
+        assert errors == ['limit exceeded']
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_speechmatic_routes.py
+++ b/tests/test_speechmatic_routes.py
@@ -122,6 +122,22 @@ class TestGenerateTranscript:
             res = self._post(auth_client, {'pid': 'abc', 'department': 'vrt'})
         assert res.status_code == HTTPStatus.OK
 
+    def test_rejected_job_with_no_processed_at_allows_restart(self, auth_client):
+        """A rejected job (processed_at=None) must not block a new submission."""
+        mam_data = {'Internal': {'PathToVideo': 'https://media.example.com/video.mp4'}}
+        rejected_job = {'id': 1, 'status': 'rejected', 'processed_at': None, 'speechmatic_job_id': 'old-sm'}
+        with patch('app.redactietool.MediahavenApi') as MockMH, \
+             patch('app.redactietool.JobsService') as MockJobs, \
+             patch('app.redactietool.ConverterService') as MockConverter, \
+             patch('app.redactietool.SpeechmaticsApi') as MockSM:
+            MockMH.return_value.find_item_by_pid.return_value = mam_data
+            MockJobs.return_value.get_job.return_value = rejected_job
+            MockConverter.return_value.get_media_url.return_value = 'https://media.example.com/video.mp4?token=tok'
+            MockSM.return_value.launch_job.return_value = 'new-sm-id'
+            MockJobs.return_value.update_job.return_value = {**rejected_job, 'speechmatic_job_id': 'new-sm-id', 'status': 'created'}
+            res = self._post(auth_client, {'pid': 'abc', 'department': 'vrt'})
+        assert res.status_code == HTTPStatus.OK
+
 
 # ---------------------------------------------------------------------------
 # GET /<department>/<pid>/speechmatic/status
@@ -158,7 +174,7 @@ class TestTranscriptionStatus:
         with patch('app.redactietool.JobsService') as MockJobs, \
              patch('app.redactietool.SpeechmaticsApi') as MockSM:
             MockJobs.return_value.get_job.return_value = job
-            MockSM.return_value.get_job_status.return_value = 'running'
+            MockSM.return_value.get_job_status.return_value = ('running', [])
             res = auth_client.get(self._url())
         assert res.status_code == HTTPStatus.OK
         data = res.get_json()
@@ -169,7 +185,7 @@ class TestTranscriptionStatus:
         with patch('app.redactietool.JobsService') as MockJobs, \
              patch('app.redactietool.SpeechmaticsApi') as MockSM:
             MockJobs.return_value.get_job.return_value = job
-            MockSM.return_value.get_job_status.return_value = 'done'
+            MockSM.return_value.get_job_status.return_value = ('done', [])
             auth_client.get(self._url())
         MockJobs.return_value.update_job_status.assert_called_once_with(1, 'done')
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-4090

allow the user to retry a failed job
handle and show errors from speechmatics in UI
store results of job in database right when status becomes "done" before the client reloads the page

before:
<img width="1710" height="1273" alt="image" src="https://github.com/user-attachments/assets/7967e496-1dd8-4426-bd37-1b8aaee2c3c9" />



after:
<img width="1710" height="1273" alt="image" src="https://github.com/user-attachments/assets/a213b5e8-202b-438a-8aae-eb34fca70db4" />

<img width="1710" height="1273" alt="image" src="https://github.com/user-attachments/assets/4557bc1c-2e15-47f8-892d-9b1f6ddb439a" />
