### PR TITLE
fix(AVO-2313): correctly encode bold and italic with dashes inside

### DIFF
--- a/app/templates/metadata/sections/inhoud_section.html
+++ b/app/templates/metadata/sections/inhoud_section.html
@@ -81,7 +81,7 @@
     update_richtext(); 
   }
 
-  var turndownService = new TurndownService();
+  var turndownService = new TurndownService({ emDelimiter: '*' });
   var quill = new Quill('#redactietool-richtext-editor', {
     modules: {
       toolbar: [


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/AVO-2313

before:
<img width="640" height="374" alt="image" src="https://github.com/user-attachments/assets/ee14bec8-6cb0-4ae6-b8fd-0b264cbf7083" />



after:
<img width="1103" height="646" alt="image" src="https://github.com/user-attachments/assets/82185c20-1945-40a4-8ceb-50916631ff5b" />
